### PR TITLE
Ignore window operations on secondary monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ gnome-shell-extension-tool -e fullscreenworkspace@satran.in
 
 # Caveats
 * The latest version I have only GNOME 41, I'm not sure if this works with older systems.
-- Works best with a single monitor, it does work with multiple monitors but is a bit wonky.
+- Works best with a single monitor. When used with multiple monitors, workspaces are not affected if maximized/restored windows are on secondary displays.

--- a/extension.js
+++ b/extension.js
@@ -8,68 +8,68 @@ const Main = imports.ui.main;
 
 
 class Extension {
-    constructor() {
-        this._maximized = GObject.type_from_name('gboolean');
-	this._handles = [];
-	this._previousWorkspace = {};
-    }
+	constructor() {
+		this._maximized = GObject.type_from_name('gboolean');
+		this._handles = [];
+		this._previousWorkspace = {};
+	}
 
-    maximize(act) {
-	const win = act.meta_window;
-	if (win.window_type !== Meta.WindowType.NORMAL)
-    	    return;
-	// If the current workspace doesn't have any other windows make it maximized here.
-	if (global.workspace_manager.get_active_workspace().list_windows().length == 1)
-	    return;
-	this._previousWorkspace[win.toString()] = global.workspace_manager.get_active_workspace_index();
-	let lastworkspace = global.workspace_manager.n_workspaces;
-	if (lastworkspace<1)
-	    lastworkspace=1;
-	win.change_workspace_by_index(lastworkspace,1);
-	global.workspace_manager.get_workspace_by_index(lastworkspace).activate(global.get_current_time());
-    }
+	maximize(act) {
+		const win = act.meta_window;
+		if (win.window_type !== Meta.WindowType.NORMAL)
+			return;
+		// If the current workspace doesn't have any other windows make it maximized here.
+		if (global.workspace_manager.get_active_workspace().list_windows().length == 1)
+			return;
+		this._previousWorkspace[win.toString()] = global.workspace_manager.get_active_workspace_index();
+		let lastworkspace = global.workspace_manager.n_workspaces;
+		if (lastworkspace < 1)
+			lastworkspace = 1;
+		win.change_workspace_by_index(lastworkspace, 1);
+		global.workspace_manager.get_workspace_by_index(lastworkspace).activate(global.get_current_time());
+	}
 
-    unmaximize(act){
-	const win = act.meta_window;
-	if (win.window_type !== Meta.WindowType.NORMAL)
-    	    return;
-	let previous = this._previousWorkspace[win.toString()];
-	if (previous == null || previous == undefined)
-	    return;
-	delete this._previousWorkspace[win.toString()];
-	win.change_workspace_by_index(previous, 1);
-	let fullScreenWorkspace = global.workspace_manager.get_active_workspace();
-	global.workspace_manager.get_workspace_by_index(previous).activate(global.get_current_time());
-	global.workspaceManager.remove_workspace(fullScreenWorkspace);
-    }
-    
-    enable() {
-        log(`enabling ${Me.metadata.name}`);
-        this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.fullscreenworkspace');
+	unmaximize(act) {
+		const win = act.meta_window;
+		if (win.window_type !== Meta.WindowType.NORMAL)
+			return;
+		let previous = this._previousWorkspace[win.toString()];
+		if (previous == null || previous == undefined)
+			return;
+		delete this._previousWorkspace[win.toString()];
+		win.change_workspace_by_index(previous, 1);
+		let fullScreenWorkspace = global.workspace_manager.get_active_workspace();
+		global.workspace_manager.get_workspace_by_index(previous).activate(global.get_current_time());
+		global.workspaceManager.remove_workspace(fullScreenWorkspace);
+	}
 
-	this._handles.push(global.window_manager.connect('size-change', (_, act, change) => {
-	    if (this.settings.get_boolean('maximized-windows')) {
-		if (change === Meta.SizeChange.MAXIMIZE) this.maximize(act);
-		if (change === Meta.SizeChange.UNMAXIMIZE) this.unmaximize(act);
-	    }
-	    if (change === Meta.SizeChange.FULLSCREEN) this.maximize(act);
-	    if (change === Meta.SizeChange.UNFULLSCREEN) this.unmaximize(act);
-	}));
+	enable() {
+		log(`enabling ${Me.metadata.name}`);
+		this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.fullscreenworkspace');
 
-	this._handles.push(global.window_manager.connect('destroy', (_, act, change) => {
-	    this.unmaximize(act)
-	}));
-    }
+		this._handles.push(global.window_manager.connect('size-change', (_, act, change) => {
+			if (this.settings.get_boolean('maximized-windows')) {
+				if (change === Meta.SizeChange.MAXIMIZE) this.maximize(act);
+				if (change === Meta.SizeChange.UNMAXIMIZE) this.unmaximize(act);
+			}
+			if (change === Meta.SizeChange.FULLSCREEN) this.maximize(act);
+			if (change === Meta.SizeChange.UNFULLSCREEN) this.unmaximize(act);
+		}));
 
-    disable() {
-	this._indicator.destroy();
-	this._indicator = null;
-	this._handles.splice(0).forEach(h => global.window_manager.disconnect(h));
-    }
+		this._handles.push(global.window_manager.connect('destroy', (_, act, change) => {
+			this.unmaximize(act)
+		}));
+	}
+
+	disable() {
+		this._indicator.destroy();
+		this._indicator = null;
+		this._handles.splice(0).forEach(h => global.window_manager.disconnect(h));
+	}
 }
 
 
 function init() {
-    return new Extension();
+	return new Extension();
 }
 

--- a/extension.js
+++ b/extension.js
@@ -47,7 +47,10 @@ class Extension {
 		log(`enabling ${Me.metadata.name}`);
 		this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.fullscreenworkspace');
 
-		this._handles.push(global.window_manager.connect('size-change', (_, act, change) => {
+		this._handles.push(global.window_manager.connect('size-change', (_, act, change, from, to) => {
+			let dis = global.get_display();
+			if (dis.get_primary_monitor() != dis.get_monitor_index_for_rect(to)) return;
+
 			if (this.settings.get_boolean('maximized-windows')) {
 				if (change === Meta.SizeChange.MAXIMIZE) this.maximize(act);
 				if (change === Meta.SizeChange.UNMAXIMIZE) this.unmaximize(act);


### PR DESCRIPTION
As per gnome default behavior, workspaces are enabled only on primary monitor.
Enabling workspaces on secondary monitors is non standard, and requires some effort.

Given this, I believe it makes sense to disable extension operation on secondary monitors.
We can also remove wonkiness caveat :D