### PR TITLE
Don't remove old workspace

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -40,7 +40,6 @@ class Extension {
 		win.change_workspace_by_index(previous, 1);
 		let fullScreenWorkspace = global.workspace_manager.get_active_workspace();
 		global.workspace_manager.get_workspace_by_index(previous).activate(global.get_current_time());
-		global.workspaceManager.remove_workspace(fullScreenWorkspace, global.get_current_time());
 	}
 
 	enable() {


### PR DESCRIPTION
It seems gnome does this for us now so this function causes the whole desktop to crash. :(

see: https://github.com/satran/fullscreenworkspace-satran.in/issues/22